### PR TITLE
Include C# as a language

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -9,7 +9,7 @@ export interface EmbedCodeFileSettings {
 }
 
 export const DEFAULT_SETTINGS: EmbedCodeFileSettings = {
-	includedLanguages: 'c,cpp,java,python,go,ruby,javascript,js,typescript,ts,shell,sh,bash',
+	includedLanguages: 'c,cs,cpp,java,python,go,ruby,javascript,js,typescript,ts,shell,sh,bash',
 	titleBackgroundColor: "#00000020",
 	titleFontColor: ""
 }


### PR DESCRIPTION
Added the .cs file extension to enable C# files to be displayed with the plugin.  I tested that this works without other changes.