### PR TITLE
added tags as an alternative for line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ where `PATH`, `LINES` and `TITLE` properties are set as YAML key-value pairs:
 * The `LINES` will include only the specified lines of the code file. Every set of included lines either range or explicit line will append dots (`...`) to included line in a newline. If you want to get rid of dots, minimize the number of sets by using one range as much as you can.
 
 
-* The `TAGS` will include only the lines between the tags, which may be comments. It does not include the tagges lines.  
+* The `TAGS` is an alternative method to specify one ore more code block of a file. It will include only the lines between the tags, which may be comments. It does not include the tagged lines.  
 
 ````yaml
 ```embed-js

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ where `PATH`, `LINES` and `TITLE` properties are set as YAML key-value pairs:
 
 * The `LINES` will include only the specified lines of the code file. Every set of included lines either range or explicit line will append dots (`...`) to included line in a newline. If you want to get rid of dots, minimize the number of sets by using one range as much as you can.
 
+
+* The `TAGS` will include only the lines between the tags, which may be comments. It does not include the tagges lines.  
+
+````yaml
+```embed-js
+PATH: "vault://H-ToHTML/js/test.js"
+TAGS: "// array02"
+TITLE: "Javascript Arrays"
+```
+````
+
+Example:
+```js
+// array02
+{
+    const array = []; // const: Veränderung des Array OK, neue Zuweisung nicht!
+    for (let i = 0; i < 10; ++i) {
+        array.push(i);  // Ans Ende anfügen
+    }
+    console.log(array); // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+}
+// array02
+```
+
+
+
 * If `TITLE` is not set, then the title of the code block will be `PATH` value.
 
 You can use also `TITLE` with normal code block (without `embed-`), but make sure that the title value is set with double quotes:

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
-import { Plugin, MarkdownRenderer, TFile, MarkdownPostProcessorContext, MarkdownView, parseYaml, requestUrl} from 'obsidian';
-import { EmbedCodeFileSettings, EmbedCodeFileSettingTab, DEFAULT_SETTINGS} from "./settings";
-import { analyseSrcLines, extractSrcLines} from "./utils";
+import { Plugin, MarkdownRenderer, TFile, MarkdownPostProcessorContext, MarkdownView, parseYaml, requestUrl } from 'obsidian';
+import { EmbedCodeFileSettings, EmbedCodeFileSettingTab, DEFAULT_SETTINGS } from "./settings";
+import { analyseSrcLines, extractSrcLines } from "./utils";
 
 export default class EmbedCodeFile extends Plugin {
 	settings: EmbedCodeFileSettings;
@@ -38,7 +38,7 @@ export default class EmbedCodeFile extends Plugin {
 			let metaYaml: any
 			try {
 				metaYaml = parseYaml(meta)
-			} catch(e) {
+			} catch (e) {
 				await MarkdownRenderer.renderMarkdown("`ERROR: invalid embedding (invalid YAML)`", el, '', this)
 				return
 			}
@@ -51,15 +51,15 @@ export default class EmbedCodeFile extends Plugin {
 
 			if (srcPath.startsWith("https://") || srcPath.startsWith("http://")) {
 				try {
-					let httpResp = await requestUrl({url: srcPath, method: "GET"})
+					let httpResp = await requestUrl({ url: srcPath, method: "GET" })
 					fullSrc = httpResp.text
-				} catch(e) {
+				} catch (e) {
 					const errMsg = `\`ERROR: could't fetch '${srcPath}'\``
 					await MarkdownRenderer.renderMarkdown(errMsg, el, '', this)
 					return
 				}
 			} else if (srcPath.startsWith("vault://")) {
-				srcPath = srcPath.replace(/^(vault:\/\/)/,'');
+				srcPath = srcPath.replace(/^(vault:\/\/)/, '');
 
 				const tFile = app.vault.getAbstractFileByPath(srcPath)
 				if (tFile instanceof TFile) {
@@ -86,6 +86,17 @@ export default class EmbedCodeFile extends Plugin {
 			} else {
 				src = extractSrcLines(fullSrc, srcLinesNum)
 			}
+
+			// ADR
+			const tags = metaYaml.TAGS
+			if (tags) {
+				const rx = new RegExp(`${tags}(.*?)${tags}`, "s");
+				const m = rx.exec(src);
+				if (m !== null) {
+					src = m[1];
+				}
+			}
+
 
 			let title = metaYaml.TITLE
 			if (!title) {
@@ -142,8 +153,8 @@ export default class EmbedCodeFile extends Plugin {
 
 	insertTitlePreElement(pre: HTMLPreElement, title: string) {
 		pre
-		.querySelectorAll(".obsidian-embed-code-file")
-		.forEach((x) => x.remove());
+			.querySelectorAll(".obsidian-embed-code-file")
+			.forEach((x) => x.remove());
 
 		let titleElement = document.createElement("pre");
 		titleElement.appendText(title);


### PR DESCRIPTION
Select code from a file by giving tags; select code between two identical tags.

Seems better when editing files and re-calculating line numbers.